### PR TITLE
Initial implementation

### DIFF
--- a/.cookiecutter/includes/README/head.md
+++ b/.cookiecutter/includes/README/head.md
@@ -1,0 +1,28 @@
+`gh-pr-upsert` creates or updates a GitHub pull request (PR) with the commits
+on your current branch:
+
+```console
+$ git clone https://github.com/$YOUR_OWNER/$YOUR_REPO.git
+$ cd $YOUR_REPO
+$ git switch -c $YOUR_BRANCH
+$ echo $YOUR_CHANGES >> README.md
+$ git commit README.md --message "$YOUR_COMMIT_MESSAGE"
+$ gh-pr-upsert --title "$YOUR_PR_TITLE" --body "$YOUR_PR_BODY"
+https://github.com/<YOUR_OWNER>/<YOUR_REPO>/pull/1
+```
+
+See `gh-pr-upsert --help` for command line options.
+
+If a PR for `$YOUR_BRANCH` already exists then it'll be updated by
+force-pushing.
+
+If there are no changes on `$YOUR_BRANCH` compared to the base branch then any
+existing PR for `$YOUR_BRANCH` will be closed: the PR apparently isn't needed
+anymore.
+
+`gh-pr-upsert` won't force-push any branches or close any PRs that contain
+commits from anyone other than the current user (as reported by
+`git config --get user.name` and `git config --get user.email`).
+
+Requires [Git](https://git-scm.com/) and [GitHub CLI](https://cli.github.com/)
+to be installed.

--- a/.cookiecutter/includes/tox/deps
+++ b/.cookiecutter/includes/tox/deps
@@ -1,0 +1,1 @@
+dev,tests,functests,lint: pytest-factoryboy

--- a/README.md
+++ b/README.md
@@ -9,6 +9,35 @@
 
 Upsert GitHub pull requests.
 
+`gh-pr-upsert` creates or updates a GitHub pull request (PR) with the commits
+on your current branch:
+
+```console
+$ git clone https://github.com/$YOUR_OWNER/$YOUR_REPO.git
+$ cd $YOUR_REPO
+$ git switch -c $YOUR_BRANCH
+$ echo $YOUR_CHANGES >> README.md
+$ git commit README.md --message "$YOUR_COMMIT_MESSAGE"
+$ gh-pr-upsert --title "$YOUR_PR_TITLE" --body "$YOUR_PR_BODY"
+https://github.com/<YOUR_OWNER>/<YOUR_REPO>/pull/1
+```
+
+See `gh-pr-upsert --help` for command line options.
+
+If a PR for `$YOUR_BRANCH` already exists then it'll be updated by
+force-pushing.
+
+If there are no changes on `$YOUR_BRANCH` compared to the base branch then any
+existing PR for `$YOUR_BRANCH` will be closed: the PR apparently isn't needed
+anymore.
+
+`gh-pr-upsert` won't force-push any branches or close any PRs that contain
+commits from anyone other than the current user (as reported by
+`git config --get user.name` and `git config --get user.email`).
+
+Requires [Git](https://git-scm.com/) and [GitHub CLI](https://cli.github.com/)
+to be installed.
+
 ## Installing
 
 We recommend using [pipx](https://pypa.github.io/pipx/) to install

--- a/src/gh_pr_upsert/cli.py
+++ b/src/gh_pr_upsert/cli.py
@@ -1,13 +1,97 @@
+import sys
 from argparse import ArgumentParser
 from importlib.metadata import version
+from subprocess import CalledProcessError
+
+from gh_pr_upsert import core, git
+from gh_pr_upsert.exceptions import PRUpsertError
 
 
-def cli(_argv=None):  # pylint:disable=inconsistent-return-statements
-    parser = ArgumentParser()
+def cli(_argv=None):  # pylint:disable=too-complex
+    parser = ArgumentParser(description="Create or update a GitHub pull request.")
     parser.add_argument("-v", "--version", action="store_true")
+    parser.add_argument(
+        "--base-remote",
+        help="the git remote to use for the base of the pull request (default: 'origin')",
+        default="origin",
+    )
+    parser.add_argument(
+        "--base-branch",
+        help="the git branch to use for the base of the pull request (default: --base-remote's default branch)",
+    )
+    parser.add_argument(
+        "--local-branch",
+        help="the local git branch to push (default: the current branch)",
+    )
+    parser.add_argument(
+        "--head-remote",
+        help="the git remote to use for the head of the pull request (default: 'origin')",
+        default="origin",
+    )
+    parser.add_argument(
+        "--head-branch",
+        help="the git branch to use for the head of the pull request (default: the branch on --head-remote with same name as --local-branch)",
+    )
+    parser.add_argument(
+        "--title",
+        help="the title to use when creating new pull requests",
+        default="Automated changes by gh-pr-upsert",
+    )
+    parser.add_argument(
+        "--body",
+        help="the body to use when creating new pull requests",
+        default="Automated changes by [gh-pr-upsert](https://github.com/hypothesis/gh-pr-upsert).",
+    )
+    parser.add_argument(
+        "--body-file",
+        help="path to a file containing the body text to use when creating new pull requests",
+    )
+    parser.add_argument(
+        "--close-comment",
+        help="the comment to leave on PRs when closing them",
+        default="It looks like this PR isn't needed anymore, closing it.",
+    )
 
     args = parser.parse_args(_argv)
 
     if args.version:
         print(version("gh-pr-upsert"))
-        return 0
+        sys.exit()
+
+    base_repo = git.GitHubRepo.get(args.base_remote)
+    head_repo = git.GitHubRepo.get(args.head_remote)
+
+    if args.base_branch is None:
+        args.base_branch = base_repo.default_branch
+
+    if args.local_branch is None:
+        args.local_branch = git.current_branch()
+
+    if args.head_branch is None:
+        args.head_branch = args.local_branch
+
+    if args.body_file is not None:  # pragma: no cover
+        # --body-file overrides --body if both are given at once.
+        with open(args.body_file, "r", encoding="utf-8") as body_file:
+            args.body = body_file.read()
+
+    try:
+        core.pr_upsert(
+            base_repo,
+            args.base_branch,
+            args.local_branch,
+            head_repo,
+            args.head_branch,
+            args.title,
+            args.body,
+            args.close_comment,
+        )
+    except PRUpsertError as err:
+        print(err.message)
+        sys.exit(err.exit_status)
+    except CalledProcessError as err:
+        if err.stderr:
+            print(err.stderr.decode("utf-8"))
+        if err.stdout:
+            print(err.stdout.decode("utf-8"))
+        raise

--- a/src/gh_pr_upsert/core.py
+++ b/src/gh_pr_upsert/core.py
@@ -18,17 +18,25 @@ def pr_upsert(
         raise SameBranchError()
 
     # The list of users who have commits on the remote branch.
-    other_contributors = {
-        commit.author
-        for commit in git.log(
-            (
-                f"{head_repo.remote}/{head_branch}",
-                f"^{local_branch}",
-                f"^{base_repo.remote}/{base_branch}",
-            )
+    commits = git.log(
+        (
+            f"{head_repo.remote}/{head_branch}",
+            f"^{local_branch}",
+            f"^{base_repo.remote}/{base_branch}",
         )
-        if commit.author != git.configured_user()
+    )
+
+    other_authors = {
+        commit.author for commit in commits if commit.author != git.configured_user()
     }
+
+    other_committers = {
+        commit.committer
+        for commit in commits
+        if commit.committer != git.configured_user()
+    }
+
+    other_contributors = other_authors | other_committers
 
     # The changes that we have locally.
     local_diff = git.diff((local_branch, f"^{base_repo.remote}/{base_branch}"))

--- a/src/gh_pr_upsert/core.py
+++ b/src/gh_pr_upsert/core.py
@@ -1,2 +1,68 @@
-def hello_world():
-    return "Hello, world!"
+from gh_pr_upsert import git
+from gh_pr_upsert.exceptions import NoChangesError, OtherPeopleError, SameBranchError
+
+
+def pr_upsert(
+    base_repo,
+    base_branch,
+    local_branch,
+    head_repo,
+    head_branch,
+    title,
+    body,
+    close_comment,
+):  # pylint:disable=too-many-arguments
+
+    # You can't send a PR to merge a branch into itself.
+    if base_repo == head_repo and base_branch == head_branch:
+        raise SameBranchError()
+
+    # The list of users who have commits on the remote branch.
+    other_contributors = {
+        commit.author
+        for commit in git.log(
+            (
+                f"{head_repo.remote}/{head_branch}",
+                f"^{local_branch}",
+                f"^{base_repo.remote}/{base_branch}",
+            )
+        )
+        if commit.author != git.configured_user()
+    }
+
+    # The changes that we have locally.
+    local_diff = git.diff((local_branch, f"^{base_repo.remote}/{base_branch}"))
+
+    # The existing PR or None.
+    pull_request = git.PullRequest.get(base_repo, base_branch, head_repo, head_branch)
+
+    # If there are no local changes then close any existing PR.
+    if not local_diff:
+        if pull_request and not other_contributors:
+            print(f"Closed PR {pull_request.html_url}")
+            pull_request.close(close_comment)
+
+        raise NoChangesError()
+
+    # The changes that already exist on the remote branch.
+    if git.branch_exists(head_repo.remote, head_branch):
+        remote_diff = git.diff(
+            (f"{head_repo.remote}/{head_branch}", f"^{base_repo.remote}/{base_branch}")
+        )
+    else:
+        remote_diff = None
+
+    # Force-push any local changes to the remote branch.
+    if local_diff != remote_diff:
+        if other_contributors:
+            raise OtherPeopleError()
+
+        git.push(head_repo.remote, local_branch, head_branch)
+
+    # Create a PR if there isn't one already.
+    if not pull_request:
+        pull_request = git.PullRequest.create(
+            base_repo, base_branch, head_repo, head_branch, title, body
+        )
+
+    print(pull_request.html_url)

--- a/src/gh_pr_upsert/exceptions.py
+++ b/src/gh_pr_upsert/exceptions.py
@@ -1,0 +1,20 @@
+class PRUpsertError(Exception):
+    """Base class for all exceptions deliberately raised by gh_pr_upsert."""
+
+    message = ""
+    exit_status = 1
+
+
+class SameBranchError(PRUpsertError):
+    message = "You must change to a different branch before creating a PR"
+    exit_status = 2
+
+
+class NoChangesError(PRUpsertError):
+    message = "Your branch has no changes compared to the default branch"
+    exit_status = 3
+
+
+class OtherPeopleError(PRUpsertError):
+    message = "Other people have pushed commits to the branch, not updating it"
+    exit_status = 4

--- a/src/gh_pr_upsert/git.py
+++ b/src/gh_pr_upsert/git.py
@@ -17,6 +17,7 @@ class User:
 class Commit:
     sha: str
     author: User
+    committer: User
 
     @classmethod
     @cache
@@ -33,6 +34,10 @@ class Commit:
             author=User(
                 name=git_show("%an"),
                 email=git_show("%ae"),
+            ),
+            committer=User(
+                name=git_show("%cn"),
+                email=git_show("%ce"),
             ),
         )
 

--- a/src/gh_pr_upsert/git.py
+++ b/src/gh_pr_upsert/git.py
@@ -1,0 +1,223 @@
+"""Helpers for working with Git and GitHub."""
+from dataclasses import dataclass, field
+from functools import cache
+from subprocess import CalledProcessError
+from typing import Optional
+
+from gh_pr_upsert.run import run
+
+
+@dataclass(frozen=True)
+class User:
+    name: str
+    email: str
+
+
+@dataclass(frozen=True)
+class Commit:
+    sha: str
+    author: User
+
+    @classmethod
+    @cache
+    def get(cls, sha: str):
+        def git_show(format_string: str) -> str:
+            return run(["git", "show", "--no-patch", f"--format={format_string}", sha])
+
+        # `git show` doesn't have a machine-readable output mode (like a --json
+        # mode) and I don't fancy writing code to parse its human-readable
+        # output. So call `git show` multiple times with a different --format
+        # string each time to extract the different attributes of the commit.
+        return cls(
+            sha=git_show("%H"),  # Call git to make sure we get the full SHA.
+            author=User(
+                name=git_show("%an"),
+                email=git_show("%ae"),
+            ),
+        )
+
+
+@dataclass(frozen=True)
+class GitHubRepo:
+    remote: str
+    owner: str
+    name: str
+    name_with_owner: str = field(repr=False, compare=False)
+    default_branch: str = field(repr=False, compare=False)
+    url: str = field(repr=False, compare=False)
+    json: Optional[dict] = field(repr=False, compare=False)
+
+    @classmethod
+    @cache
+    def get(cls, remote: str):
+        remote_url = run(["git", "remote", "get-url", remote])
+
+        json = run(
+            [
+                "gh",
+                "repo",
+                "view",
+                "--json",
+                "owner,name,nameWithOwner,defaultBranchRef,url",
+                remote_url,
+            ],
+            json=True,
+        )
+
+        return cls(
+            remote=remote,
+            owner=json["owner"]["login"],
+            name=json["name"],
+            name_with_owner=json["nameWithOwner"],
+            default_branch=json["defaultBranchRef"]["name"],
+            url=json["url"],
+            json=json,
+        )
+
+
+@dataclass(frozen=True)
+class PullRequest:
+    base_repo: GitHubRepo
+    head_repo: GitHubRepo
+    head_branch: str
+    number: int
+    html_url: str = field(compare=False, repr=False)
+    json: Optional[dict] = field(compare=False, repr=False)
+
+    @classmethod
+    def from_json(cls, base_repo, head_repo, head_branch, json):
+        """Return a PullRequest from the given GitHub API JSON data."""
+        return cls(
+            base_repo=base_repo,
+            head_repo=head_repo,
+            head_branch=head_branch,
+            number=json["number"],
+            html_url=json["html_url"],
+            json=json,
+        )
+
+    @classmethod
+    def create(
+        cls, base_repo, base_branch, head_repo, head_branch, title, body
+    ):  # pylint: disable=too-many-arguments
+        json = run(
+            [
+                "gh",
+                "api",
+                "--header",
+                "X-GitHub-Api-Version:2022-11-28",
+                "--method",
+                "POST",
+                f"/repos/{base_repo.owner}/{base_repo.name}/pulls",
+                "-f",
+                f"base={base_branch}",
+                "-f",
+                f"head={head_repo.owner}:{head_branch}",
+                "-f",
+                f"title={title}",
+                "-f",
+                f"body={body}",
+            ],
+            json=True,
+        )
+
+        return cls.from_json(base_repo, head_repo, head_branch, json)
+
+    @classmethod
+    @cache
+    def get(cls, base_repo, base_branch, head_repo, head_branch):
+        matching_prs = run(
+            [
+                "gh",
+                "api",
+                "--header",
+                "X-GitHub-Api-Version:2022-11-28",
+                "--paginate",
+                "--method",
+                "GET",
+                f"/repos/{base_repo.owner}/{base_repo.name}/pulls",
+                "-f",
+                f"base={base_branch}",
+                "-f",
+                f"head={head_repo.owner}:{head_branch}",
+                "-f",
+                "state=open",
+            ],
+            json=True,
+        )
+
+        if not matching_prs:
+            return None
+
+        assert len(matching_prs) == 1
+
+        json = matching_prs[0]
+
+        return cls.from_json(base_repo, head_repo, head_branch, json)
+
+    def close(self, comment) -> None:
+        run(
+            [
+                "gh",
+                "pr",
+                "close",
+                "--repo",
+                self.base_repo.name_with_owner,
+                "--delete-branch",
+                "--comment",
+                comment,
+                str(self.number),
+            ]
+        )
+
+
+@cache
+def branch_exists(remote: str, branch: str) -> bool:
+    """Return True if `remote` has a branch named `branch`."""
+    try:
+        run(["git", "show-ref", f"refs/remotes/{remote}/{branch}"])
+    except CalledProcessError as err:
+        if err.returncode == 1:
+            return False
+        raise
+
+    return True
+
+
+@cache
+def configured_user():
+    """Return the configured git user."""
+    return User(
+        name=run(["git", "config", "--get", "user.name"]),
+        email=run(["git", "config", "--get", "user.email"]),
+    )
+
+
+@cache
+def current_branch() -> str:
+    """Return the name of the current local git branch."""
+    return run(["git", "symbolic-ref", "--quiet", "--short", "HEAD"])
+
+
+@cache
+def diff(branches: list[str]) -> str:
+    """Return the output of `git diff <branch>...` for the given `branches`."""
+    return run(["git", "diff", *branches])
+
+
+@cache
+def log(branches: list[str]) -> list[Commit]:
+    """Return the commits from `git log <branch>...` for the given `branches`."""
+    return [
+        Commit.get(sha)
+        for sha in run(
+            ["git", "log", "--ignore-missing", *branches, "--format=%H"]
+        ).split()
+    ]
+
+
+def push(remote: str, local_branch: str, remote_branch: str) -> None:
+    """Force-push <local_branch> to <remote>/<remote_branch>."""
+    run(
+        ["git", "push", "--force-with-lease", remote, f"{local_branch}:{remote_branch}"]
+    )

--- a/src/gh_pr_upsert/run.py
+++ b/src/gh_pr_upsert/run.py
@@ -1,0 +1,17 @@
+"""Helper functions for running subprocesses."""
+import json as json_
+import os
+import subprocess
+
+
+def run(cmd, json=False):
+    """Run a command in a subprocess and returns its stdout."""
+    if os.environ.get("DEBUG") == "yes":
+        print(cmd)
+
+    stdout = subprocess.run(cmd, check=True, capture_output=True).stdout
+
+    if json:
+        return json_.loads(stdout)
+
+    return stdout.decode("utf-8").strip()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,20 @@
+import factory.random
+import pytest
+from pytest_factoryboy import register
+
+from tests import factories
+
+register(factories.UserFactory)
+register(factories.CommitFactory)
+register(factories.GitHubRepoFactory)
+register(factories.GitHubRepoFactory, _name="base_repo")
+register(factories.GitHubRepoFactory, _name="head_repo")
+register(factories.PullRequestFactory)
+
+
+@pytest.fixture(scope="session", autouse=True)
+def factory_boy_random_seed():
+    # Set factory_boy's random seed so that it produces the same random values
+    # in each run of the tests.
+    # See: https://factoryboy.readthedocs.io/en/latest/index.html#reproducible-random-values
+    factory.random.reseed_random("hypothesis/gh-pr-upsert")

--- a/tests/factories.py
+++ b/tests/factories.py
@@ -17,6 +17,7 @@ class CommitFactory(factory.Factory):
 
     sha = factory.Faker("sha1")
     author = factory.SubFactory(UserFactory)
+    committer = factory.SubFactory(UserFactory)
 
 
 class GitHubRepoFactory(factory.Factory):

--- a/tests/factories.py
+++ b/tests/factories.py
@@ -1,0 +1,46 @@
+import factory
+
+from gh_pr_upsert import git
+
+
+class UserFactory(factory.Factory):
+    class Meta:
+        model = git.User
+
+    name = factory.Sequence(lambda n: f"User {n}")
+    email = factory.Sequence(lambda n: f"user_{n}@example.com")
+
+
+class CommitFactory(factory.Factory):
+    class Meta:
+        model = git.Commit
+
+    sha = factory.Faker("sha1")
+    author = factory.SubFactory(UserFactory)
+
+
+class GitHubRepoFactory(factory.Factory):
+    class Meta:
+        model = git.GitHubRepo
+
+    remote = "origin"
+    owner = factory.Sequence(lambda n: f"user-{n}")
+    name = factory.Sequence(lambda n: f"repo-{n}")
+    name_with_owner = factory.LazyAttribute(lambda o: f"{o.owner}/{o.name}")
+    default_branch = factory.Faker("random_element", elements=["main", "master"])
+    url = factory.LazyAttribute(lambda o: f"https://github.com/{o.owner}/{o.name}")
+    json = None
+
+
+class PullRequestFactory(factory.Factory):
+    class Meta:
+        model = git.PullRequest
+
+    base_repo = factory.SubFactory(GitHubRepoFactory)
+    head_repo = factory.SubFactory(GitHubRepoFactory)
+    head_branch = factory.Faker("word")
+    number = factory.Sequence(lambda n: n)
+    html_url = factory.LazyAttribute(
+        lambda o: f"https://github.com/{o.base_repo.owner}/{o.base_repo.name}/pull/{o.number}"
+    )
+    json = None

--- a/tests/unit/gh_pr_upsert/cli_test.py
+++ b/tests/unit/gh_pr_upsert/cli_test.py
@@ -1,12 +1,11 @@
 from importlib.metadata import version
+from subprocess import CalledProcessError
+from unittest.mock import call, sentinel
 
 import pytest
 
 from gh_pr_upsert.cli import cli
-
-
-def test_it():
-    cli([])
+from gh_pr_upsert.exceptions import NoChangesError
 
 
 def test_help():
@@ -17,7 +16,105 @@ def test_help():
 
 
 def test_version(capsys):
-    exit_code = cli(["--version"])
+    with pytest.raises(SystemExit) as exc_info:
+        cli(["--version"])
 
     assert capsys.readouterr().out.strip() == version("gh-pr-upsert")
-    assert not exit_code
+    assert not exc_info.value.code
+
+
+def test_defaults(core, base_repo, head_repo, git):
+    cli([])
+
+    assert git.GitHubRepo.get.call_args_list == [call("origin"), call("origin")]
+    git.current_branch.assert_called_once_with()
+    core.pr_upsert.assert_called_once_with(
+        base_repo,
+        base_repo.default_branch,
+        git.current_branch.return_value,
+        head_repo,
+        git.current_branch.return_value,
+        "Automated changes by gh-pr-upsert",
+        "Automated changes by [gh-pr-upsert](https://github.com/hypothesis/gh-pr-upsert).",
+        "It looks like this PR isn't needed anymore, closing it.",
+    )
+
+
+def test_options(core, base_repo, head_repo, git):
+    cli(
+        [
+            "--base-remote",
+            "my_base_remote",
+            "--base-branch",
+            "my_base_branch",
+            "--local-branch",
+            "my_local_branch",
+            "--head-remote",
+            "my_head_remote",
+            "--head-branch",
+            "my_head_branch",
+            "--title",
+            "my_title",
+            "--body",
+            "my_body",
+            "--close-comment",
+            "my_close_comment",
+        ]
+    )
+
+    assert git.GitHubRepo.get.call_args_list == [
+        call("my_base_remote"),
+        call("my_head_remote"),
+    ]
+    core.pr_upsert.assert_called_once_with(
+        base_repo,
+        "my_base_branch",
+        "my_local_branch",
+        head_repo,
+        "my_head_branch",
+        "my_title",
+        "my_body",
+        "my_close_comment",
+    )
+
+
+def test_PRUpsertError(capsys, core):
+    core.pr_upsert.side_effect = NoChangesError()
+
+    with pytest.raises(SystemExit) as exc_info:
+        cli([])
+
+    assert capsys.readouterr().out.strip() == NoChangesError.message
+    assert exc_info.value.code == NoChangesError.exit_status
+
+
+def test_CalledProcessError(core):
+    error = core.pr_upsert.side_effect = CalledProcessError(23, sentinel.cmd)
+
+    with pytest.raises(CalledProcessError) as exc_info:
+        cli([])
+
+    assert exc_info.value == error
+
+
+def test_it_prints_stdout_and_stderr_from_CalledProcessErrors(capsys, core):
+    core.pr_upsert.side_effect = CalledProcessError(
+        23, sentinel.cmd, b"output", b"errors"
+    )
+
+    with pytest.raises(CalledProcessError):
+        cli([])
+
+    assert capsys.readouterr().out.strip() == "errors\noutput"
+
+
+@pytest.fixture(autouse=True)
+def core(mocker):
+    return mocker.patch("gh_pr_upsert.cli.core", autospec=True)
+
+
+@pytest.fixture(autouse=True)
+def git(mocker, base_repo, head_repo):
+    git = mocker.patch("gh_pr_upsert.cli.git", autospec=True)
+    git.GitHubRepo.get.side_effect = [base_repo, head_repo]
+    return git

--- a/tests/unit/gh_pr_upsert/core_test.py
+++ b/tests/unit/gh_pr_upsert/core_test.py
@@ -212,8 +212,11 @@ class TestPRUpsert:
 
         # Make `git log` return two commits both by the configured user.
         git.configured_user.return_value = user
+
         git.log.return_value = commit_factory.create_batch(
-            2, author=git.configured_user.return_value
+            2,
+            author=git.configured_user.return_value,
+            committer=git.configured_user.return_value,
         )
 
         return git

--- a/tests/unit/gh_pr_upsert/core_test.py
+++ b/tests/unit/gh_pr_upsert/core_test.py
@@ -1,6 +1,219 @@
-from gh_pr_upsert.core import hello_world
+from unittest.mock import call, sentinel
+
+import pytest
+
+from gh_pr_upsert import core
+from gh_pr_upsert.exceptions import NoChangesError, OtherPeopleError, SameBranchError
 
 
-class TestHelloWorld:
-    def test_it(self):
-        assert hello_world() == "Hello, world!"
+class TestPRUpsert:
+    def test_it(self, base_repo, capsys, git, head_repo):
+        core.pr_upsert(
+            base_repo,
+            sentinel.base_branch,
+            sentinel.local_branch,
+            head_repo,
+            sentinel.head_branch,
+            sentinel.title,
+            sentinel.body,
+            sentinel.close_comment,
+        )
+
+        # It gets the list of commits on the remote branch compared to the local branch.
+        git.log.assert_called_once_with(
+            (
+                f"{head_repo.remote}/{sentinel.head_branch}",
+                f"^{sentinel.local_branch}",
+                f"^{base_repo.remote}/{sentinel.base_branch}",
+            )
+        )
+
+        assert git.diff.call_args_list == [
+            # It gets the diff of the local branch.
+            call(
+                (
+                    sentinel.local_branch,
+                    f"^{base_repo.remote}/{sentinel.base_branch}",
+                )
+            ),
+            # It gets the diff of the remote branch.
+            call(
+                (
+                    f"{head_repo.remote}/{sentinel.head_branch}",
+                    f"^{base_repo.remote}/{sentinel.base_branch}",
+                )
+            ),
+        ]
+
+        # It gets the existing PR.
+        git.PullRequest.get.assert_called_once_with(
+            base_repo, sentinel.base_branch, head_repo, sentinel.head_branch
+        )
+
+        # It checks whether the remote branch exists.
+        git.branch_exists.assert_called_once_with(
+            head_repo.remote, sentinel.head_branch
+        )
+
+        # It does not call `git push` because the local and remote diffs are the same.
+        git.push.assert_not_called()
+
+        # It does not create a PR because one already exists.
+        git.PullRequest.create.assert_not_called()
+
+        # It doesn't close the PR because there was a diff.
+        git.PullRequest.get.return_value.close.assert_not_called()
+
+        # It prints out the PR's URL.
+        assert capsys.readouterr().out.strip() == str(
+            git.PullRequest.get.return_value.html_url
+        )
+
+    def test_it_raises_if_the_base_and_head_branch_are_the_same(self, git_hub_repo):
+        with pytest.raises(SameBranchError):
+            core.pr_upsert(
+                git_hub_repo,
+                sentinel.remote_branch,
+                sentinel.local_branch,
+                git_hub_repo,
+                sentinel.remote_branch,
+                sentinel.title,
+                sentinel.body,
+                sentinel.close_comment,
+            )
+
+    def test_if_there_are_no_changes_it_closes_any_existing_pr(
+        self, base_repo, head_repo, git
+    ):
+        git.diff.return_value = ""
+
+        with pytest.raises(NoChangesError):
+            core.pr_upsert(
+                base_repo,
+                sentinel.base_branch,
+                sentinel.local_branch,
+                head_repo,
+                sentinel.head_branch,
+                sentinel.title,
+                sentinel.body,
+                sentinel.close_comment,
+            )
+
+        git.PullRequest.get.return_value.close.assert_called_once_with(
+            sentinel.close_comment
+        )
+
+    def test_it_doesnt_close_prs_that_have_other_contributors(
+        self, base_repo, head_repo, commit_factory, git
+    ):
+        git.diff.return_value = ""
+        git.log.return_value.append(commit_factory())
+
+        with pytest.raises(NoChangesError):
+            core.pr_upsert(
+                base_repo,
+                sentinel.base_branch,
+                sentinel.local_branch,
+                head_repo,
+                sentinel.head_branch,
+                sentinel.title,
+                sentinel.body,
+                sentinel.close_comment,
+            )
+
+        git.PullRequest.get.return_value.close.assert_not_called()
+
+    def test_if_the_remote_branch_doesnt_exist_it_creates_it(
+        self, base_repo, head_repo, git
+    ):
+        git.branch_exists.return_value = False
+
+        core.pr_upsert(
+            base_repo,
+            sentinel.base_branch,
+            sentinel.local_branch,
+            head_repo,
+            sentinel.head_branch,
+            sentinel.title,
+            sentinel.body,
+            sentinel.close_comment,
+        )
+
+        git.push.assert_called_once_with(
+            head_repo.remote, sentinel.local_branch, sentinel.head_branch
+        )
+
+    def test_if_the_remote_branch_already_exists_it_updates_it(
+        self, base_repo, head_repo, git
+    ):
+        git.diff.side_effect = [sentinel.local_diff, sentinel.remote_diff]
+
+        core.pr_upsert(
+            base_repo,
+            sentinel.base_branch,
+            sentinel.local_branch,
+            head_repo,
+            sentinel.head_branch,
+            sentinel.title,
+            sentinel.body,
+            sentinel.close_comment,
+        )
+
+        git.push.assert_called_once_with(
+            head_repo.remote, sentinel.local_branch, sentinel.head_branch
+        )
+
+    def test_it_doesnt_push_the_remote_branch_if_there_are_other_contributors(
+        self, base_repo, head_repo, commit_factory, git
+    ):
+        git.diff.side_effect = [sentinel.local_diff, sentinel.remote_diff]
+        git.log.return_value.append(commit_factory())
+
+        with pytest.raises(OtherPeopleError):
+            core.pr_upsert(
+                base_repo,
+                sentinel.base_branch,
+                sentinel.local_branch,
+                head_repo,
+                sentinel.head_branch,
+                sentinel.title,
+                sentinel.body,
+                sentinel.close_comment,
+            )
+
+        git.push.assert_not_called()
+
+    def test_if_the_pr_doesnt_exist_it_creates_one(self, base_repo, head_repo, git):
+        git.PullRequest.get.return_value = None
+
+        core.pr_upsert(
+            base_repo,
+            sentinel.base_branch,
+            sentinel.local_branch,
+            head_repo,
+            sentinel.head_branch,
+            sentinel.title,
+            sentinel.body,
+            sentinel.close_comment,
+        )
+
+        git.PullRequest.create.assert_called_once_with(
+            base_repo,
+            sentinel.base_branch,
+            head_repo,
+            sentinel.head_branch,
+            sentinel.title,
+            sentinel.body,
+        )
+
+    @pytest.fixture(autouse=True)
+    def git(self, mocker, user, commit_factory):
+        git = mocker.patch("gh_pr_upsert.core.git", autospec=True)
+
+        # Make `git log` return two commits both by the configured user.
+        git.configured_user.return_value = user
+        git.log.return_value = commit_factory.create_batch(
+            2, author=git.configured_user.return_value
+        )
+
+        return git

--- a/tests/unit/gh_pr_upsert/git_test.py
+++ b/tests/unit/gh_pr_upsert/git_test.py
@@ -23,6 +23,8 @@ class TestCommit:
             sentinel.full_sha,
             sentinel.author_name,
             sentinel.author_email,
+            sentinel.committer_name,
+            sentinel.committer_email,
         ]
 
         commit = Commit.get(sentinel.sha)
@@ -31,10 +33,15 @@ class TestCommit:
             call(["git", "show", "--no-patch", "--format=%H", sentinel.sha]),
             call(["git", "show", "--no-patch", "--format=%an", sentinel.sha]),
             call(["git", "show", "--no-patch", "--format=%ae", sentinel.sha]),
+            call(["git", "show", "--no-patch", "--format=%cn", sentinel.sha]),
+            call(["git", "show", "--no-patch", "--format=%ce", sentinel.sha]),
         ]
         assert commit == Commit(
             sha=sentinel.full_sha,
             author=User(name=sentinel.author_name, email=sentinel.author_email),
+            committer=User(
+                name=sentinel.committer_name, email=sentinel.committer_email
+            ),
         )
 
 

--- a/tests/unit/gh_pr_upsert/git_test.py
+++ b/tests/unit/gh_pr_upsert/git_test.py
@@ -1,0 +1,336 @@
+from subprocess import CalledProcessError
+from unittest.mock import call, sentinel
+
+import pytest
+
+from gh_pr_upsert.git import (
+    Commit,
+    GitHubRepo,
+    PullRequest,
+    User,
+    branch_exists,
+    configured_user,
+    current_branch,
+    diff,
+    log,
+    push,
+)
+
+
+class TestCommit:
+    def test_get(self, run):
+        run.side_effect = [
+            sentinel.full_sha,
+            sentinel.author_name,
+            sentinel.author_email,
+        ]
+
+        commit = Commit.get(sentinel.sha)
+
+        assert run.call_args_list == [
+            call(["git", "show", "--no-patch", "--format=%H", sentinel.sha]),
+            call(["git", "show", "--no-patch", "--format=%an", sentinel.sha]),
+            call(["git", "show", "--no-patch", "--format=%ae", sentinel.sha]),
+        ]
+        assert commit == Commit(
+            sha=sentinel.full_sha,
+            author=User(name=sentinel.author_name, email=sentinel.author_email),
+        )
+
+
+class TestGitHubRepo:
+    def test_get(self, run):
+        # The JSON returned by `gh repo view`.
+        json = {
+            "name": sentinel.repo_name,
+            "nameWithOwner": sentinel.repo_name_with_owner,
+            "url": sentinel.repo_url,
+            "owner": {"login": sentinel.owner_login},
+            "defaultBranchRef": {"name": sentinel.default_branch_name},
+        }
+        run.side_effect = [sentinel.remote_url, json]
+
+        repo = GitHubRepo.get(sentinel.remote)
+
+        assert run.call_args_list == [
+            call(["git", "remote", "get-url", sentinel.remote]),
+            call(
+                [
+                    "gh",
+                    "repo",
+                    "view",
+                    "--json",
+                    "owner,name,nameWithOwner,defaultBranchRef,url",
+                    sentinel.remote_url,
+                ],
+                json=True,
+            ),
+        ]
+        assert repo == GitHubRepo(
+            remote=sentinel.remote,
+            owner=sentinel.owner_login,
+            name=sentinel.repo_name,
+            name_with_owner=sentinel.repo_name_with_owner,
+            default_branch=sentinel.default_branch_name,
+            url=sentinel.repo_url,
+            json=json,
+        )
+
+
+class TestPullRequest:
+    def test_from_json(self, json):
+        pull_request = PullRequest.from_json(
+            sentinel.base_repo, sentinel.head_repo, sentinel.head_branch, json
+        )
+
+        assert pull_request == PullRequest(
+            base_repo=sentinel.base_repo,
+            head_repo=sentinel.head_repo,
+            head_branch=sentinel.head_branch,
+            number=sentinel.number,
+            html_url=sentinel.html_url,
+            json=json,
+        )
+
+    def test_create(self, base_repo, head_repo, run, json):
+        run.return_value = json
+
+        pull_request = PullRequest.create(
+            base_repo,
+            sentinel.base_branch,
+            head_repo,
+            sentinel.head_branch,
+            sentinel.title,
+            sentinel.body,
+        )
+
+        run.assert_called_once_with(
+            [
+                "gh",
+                "api",
+                "--header",
+                "X-GitHub-Api-Version:2022-11-28",
+                "--method",
+                "POST",
+                f"/repos/{base_repo.owner}/{base_repo.name}/pulls",
+                "-f",
+                f"base={sentinel.base_branch}",
+                "-f",
+                f"head={head_repo.owner}:{sentinel.head_branch}",
+                "-f",
+                f"title={sentinel.title}",
+                "-f",
+                f"body={sentinel.body}",
+            ],
+            json=True,
+        )
+        assert pull_request == PullRequest(
+            base_repo=base_repo,
+            head_repo=head_repo,
+            head_branch=sentinel.head_branch,
+            number=sentinel.number,
+            html_url=sentinel.html_url,
+            json=json,
+        )
+
+    def test_get(self, base_repo, head_repo, run, json):
+        run.return_value = [json]
+
+        pull_request = PullRequest.get(
+            base_repo, sentinel.base_branch, head_repo, sentinel.head_branch
+        )
+
+        run.assert_called_once_with(
+            [
+                "gh",
+                "api",
+                "--header",
+                "X-GitHub-Api-Version:2022-11-28",
+                "--paginate",
+                "--method",
+                "GET",
+                f"/repos/{base_repo.owner}/{base_repo.name}/pulls",
+                "-f",
+                f"base={sentinel.base_branch}",
+                "-f",
+                f"head={head_repo.owner}:{sentinel.head_branch}",
+                "-f",
+                "state=open",
+            ],
+            json=True,
+        )
+        assert pull_request == PullRequest(
+            base_repo=base_repo,
+            head_repo=head_repo,
+            head_branch=sentinel.head_branch,
+            number=sentinel.number,
+            html_url=sentinel.html_url,
+            json=json,
+        )
+
+    def test_get_returns_None_if_there_are_no_matching_prs(
+        self, base_repo, head_repo, run
+    ):
+        run.return_value = None
+
+        assert not PullRequest.get(
+            base_repo, sentinel.base_branch, head_repo, sentinel.head_branch
+        )
+
+    def test_get_raises_if_there_are_multiple_matching_prs(
+        self, base_repo, head_repo, pull_request_factory, run
+    ):
+        # Make the GitHub API return two PRs for the same base repo, head repo
+        # and head branch. This should never happen in production: there can't
+        # be two open PRs for the same base and head branch, so get() raises
+        # AssertionError.
+        run.return_value = [
+            {"number": pr.number, "html_url": pr.html_url}
+            for pr in pull_request_factory.create_batch(
+                2,
+                base_repo=base_repo,
+                head_repo=head_repo,
+                head_branch=sentinel.head_branch,
+            )
+        ]
+
+        with pytest.raises(AssertionError):
+            PullRequest.get(
+                base_repo, sentinel.base_branch, head_repo, sentinel.head_branch
+            )
+
+    def test_close(self, pull_request, run):
+        pull_request.close(sentinel.comment)
+
+        run.assert_called_once_with(
+            [
+                "gh",
+                "pr",
+                "close",
+                "--repo",
+                pull_request.base_repo.name_with_owner,
+                "--delete-branch",
+                "--comment",
+                sentinel.comment,
+                str(pull_request.number),
+            ]
+        )
+
+    @pytest.fixture
+    def json(self):
+        """Return a JSON representation of a pull request as from the GitHub API."""
+        return {"number": sentinel.number, "html_url": sentinel.html_url}
+
+
+class TestBranchExists:
+    def test_it_returns_True_if_the_branch_exists(self, run):
+        exists = branch_exists("origin", "my-branch")
+
+        run.assert_called_once_with(
+            ["git", "show-ref", "refs/remotes/origin/my-branch"]
+        )
+        assert exists
+
+    def test_it_returns_False_if_the_branch_doesnt_exist(self, run):
+        run.side_effect = CalledProcessError(returncode=1, cmd=sentinel.cmd)
+
+        assert not branch_exists("origin", "my-branch")
+
+    def test_it_raises_if_it_gets_an_unexpected_exit_code_from_git(self, run):
+        run.side_effect = CalledProcessError(returncode=2, cmd=sentinel.cmd)
+
+        with pytest.raises(CalledProcessError) as exc_info:
+            branch_exists("origin", "my-branch")
+
+        assert exc_info.value == run.side_effect
+
+
+class TestConfiguredUser:
+    def test_it(self, user, run):
+        run.side_effect = [user.name, user.email]
+
+        assert configured_user() == user
+        assert run.call_args_list == [
+            call(["git", "config", "--get", "user.name"]),
+            call(["git", "config", "--get", "user.email"]),
+        ]
+
+
+class TestCurrentBranch:
+    def test_it(self, run):
+        branch = current_branch()
+
+        run.assert_called_once_with(
+            ["git", "symbolic-ref", "--quiet", "--short", "HEAD"]
+        )
+        assert branch == run.return_value
+
+
+class TestDiff:
+    def test_it(self, run):
+        returned = diff((sentinel.branch_1, sentinel.branch_2))
+
+        run.assert_called_once_with(
+            ["git", "diff", sentinel.branch_1, sentinel.branch_2]
+        )
+        assert returned == run.return_value
+
+
+class TestLog:
+    def test_it(self, commit_factory, run, get):
+        get.side_effect = commits = commit_factory.create_batch(2)
+        run.return_value = "\n".join((commit.sha for commit in commits))
+
+        returned = log((sentinel.branch_1, sentinel.branch_2))
+
+        run.assert_called_once_with(
+            [
+                "git",
+                "log",
+                "--ignore-missing",
+                sentinel.branch_1,
+                sentinel.branch_2,
+                "--format=%H",
+            ]
+        )
+        assert get.call_args_list == [call(commits[0].sha), call(commits[1].sha)]
+        assert returned == commits
+
+    @pytest.fixture(autouse=True)
+    def get(self, mocker):
+        return mocker.patch("gh_pr_upsert.git.Commit.get", autospec=True)
+
+
+class TestPush:
+    def test_it(self, run):
+        push(sentinel.remote, sentinel.local_branch, sentinel.remote_branch)
+
+        run.assert_called_once_with(
+            [
+                "git",
+                "push",
+                "--force-with-lease",
+                sentinel.remote,
+                f"{sentinel.local_branch}:{sentinel.remote_branch}",
+            ]
+        )
+
+
+@pytest.fixture(autouse=True)
+def clear_caches():
+    yield
+
+    # pylint:disable=no-member
+    branch_exists.cache_clear()
+    configured_user.cache_clear()
+    current_branch.cache_clear()
+    diff.cache_clear()
+    log.cache_clear()
+    Commit.get.cache_clear()
+    PullRequest.get.cache_clear()
+    GitHubRepo.get.cache_clear()
+
+
+@pytest.fixture(autouse=True)
+def run(mocker):
+    return mocker.patch("gh_pr_upsert.git.run", autospec=True)

--- a/tests/unit/gh_pr_upsert/run_test.py
+++ b/tests/unit/gh_pr_upsert/run_test.py
@@ -1,0 +1,48 @@
+import json
+from subprocess import CompletedProcess
+
+import pytest
+
+from gh_pr_upsert.run import run
+
+
+def test_run(subprocess):
+    subprocess.run.return_value = CompletedProcess(
+        "args", returncode=42, stdout=b"test_output\n"
+    )
+
+    result = run("test_command")
+
+    subprocess.run.assert_called_once_with(
+        "test_command", check=True, capture_output=True
+    )
+    assert result == "test_output"
+
+
+def test_run_prints_commands_in_debug_mode(capsys, os):
+    os.environ["DEBUG"] = "yes"
+
+    run("test_command")
+
+    assert capsys.readouterr().out.strip() == "test_command"
+
+
+def test_run_loads_json(subprocess):
+    expected_result = {"foo": "bar"}
+    subprocess.run.return_value = CompletedProcess(
+        "args", returncode=42, stdout=json.dumps(expected_result)
+    )
+
+    assert run("test_command", json=True) == expected_result
+
+
+@pytest.fixture(autouse=True)
+def os(mocker):
+    os = mocker.patch("gh_pr_upsert.run.os", autospec=True)
+    os.environ = {}
+    return os
+
+
+@pytest.fixture(autouse=True)
+def subprocess(mocker):
+    return mocker.patch("gh_pr_upsert.run.subprocess", autospec=True)

--- a/tox.ini
+++ b/tox.ini
@@ -33,6 +33,7 @@ deps =
     lint,tests,functests: factory-boy
     lint,tests,functests: h-matchers
     lint,template: cookiecutter
+    dev,tests,functests,lint: pytest-factoryboy
 depends =
     coverage: tests,py{39}-tests
 commands =


### PR DESCRIPTION
## Problem

When you make a change to [our cookiecutter template](https://github.com/hypothesis/cookiecutters) you then have to run `make template` in every project that uses the cookiecutter (getting close to a couple of dozen projects) and send PRs to every project. This is a waste of developers time, it's error-prone (e.g. accidentally missing out some projects), it means that projects will tend not to be kept up-to-date with the cookiecutter (because people forget or don't have time), and it discourages making changes to the cookiecutter (if you know you're then gonna have to go and manually create a couple of dozen PRs).

We would like to automate this by having a command line script (runnable both locally and on GitHub Actions) that:

1. Finds all the cookiecutter-using projects in the hypothesis organization on GitHub
2. `git clone`'s each project
3. Runs `make template` in each project
4. Sends any resulting changes as a PR

[Commando](https://github.com/hypothesis/commando) which is very much a work-in-progress and not ready for review is intended to become a script that will implement the above steps.

**Here's the problem:** that final step (_send any resulting changes as a PR_) is more complicated than it sounds. What Commando actually needs to do is:

* Push the branch to GitHub, if it doesn't already exist
* If the branch does already exist on GitHub then update it by force-pushing
  * But don't force-push the branch if this wouldn't change the PR's final diff. For example Commando might be run on a nightly schedule. One night Commando runs `make template` and sends a PR with the changes. No developer gets around to merging this PR immediately. The next night Commando creates a fresh new branch and runs `make template` again which produces the same changes as the previous night. This will actually create a _new_ commit with a different timestamp and SHA but the same patch. In this case we don't want Commando to force-push the branch with the new commit as pointless force pushes like this do show up on pull request pages and create pointless noise.
  * Also don't force-push the branch if it has anyone else's commits on it. Imagine that Commando sends a cookiecutter update PR that actually breaks something. A human developer pushes their own commit to Commando's PR to fix the issue and requests a review from another developer. Before the PR is merged Commando runs again and force-pushes the branch, deleting the human developer's commit. Not good!
  * Also don't fall into this race condition: 1. The script checks that the branch is safe to force-push (it doesn't contain any human commits); 2. A human pushes a commit to the branch; 3. The script (having just checked that it was safe) force-pushes the branch and deletes the human's commit
* Don't open a second PR if one already exists. If Commando runs on a nightly schedule we don't want it creating one new PR every day until someone merges one of them. Instead it should update the existing PR if necessary by force-pushing the branch
* Don't do anything if `make template` didn't produce any changes (don't try to create a PR for nothing)
  * In this case if there's an already open PR then it'd be nice if the script would automatically close it. This could happen if someone merged a PR in the cookiecutters project and then reverted it, or if a separate PR was created by a human that updated the project with the cookiecutter: there might be an open cookiecutter update PR from Commando that is no longer needed. It'd be nice if a subsequent run of Commando would politely clean up after itself by closing its own no-longer-needed PRs. It'd be nice if it also posted an explanatory comment when closing a PR, and deleted the branch.

## Solution

gh-pr-upsert implements the "create or update (or close) pull request" requirements described above. This will enable us to write a simple script that finds all the projects, clones each project, runs `make template` in each project, and runs `gh-pr-upsert` to create or update a PR if necessary.

## Usage

A script needs to clone a project, make some changes to the project (e.g. by running `make template`), switch to a branch, commit the changes, then run `gh-pr-upsert`:

```console
$ git clone https://github.com/hypothesis/foo
$ cd foo
$ make template
$ git switch -c cookiecutter
$ git add .
$ git commit --message "Apply updates from cookiecutter"
$ gh-pr-upsert --title "Apply updates from cookiecutter"
```

## Terminology

* **Local branch:** the local git branch that contains the commits that will be pushed. By default this is the current branch.
* **Base remote:** the local git remote for the base repo. Default: `origin`.
* **Base repo:** the GitHub repo corresponding to the base remote.
* **Base branch:** the branch of the base repo that the pull request will be requesting the commits be merged into. By default this is the default branch, usually `main` or `master`.
* **Head remote:** the local git remote for the head repo. Default: `origin`, the same as base remote.
* **Head repo:** the GitHub repo corresponding to the head remote. By default this is the same repo as the base repo: the one for the `origin` remote.
* **Head branch:** the branch of the head repo that contains the pull request's commits. By default this is the branch of the head repo that has the same name as the local branch. The local branch will be pushed to this remote branch.

```mermaid
flowchart LR
  base(base branch)
  head(head branch)
  local(local branch)
  subgraph Your Computer
    subgraph Local Git Repo
      local
    end
  end
  subgraph GitHub
    subgraph Head Repo
      head
    end
    subgraph Base Repo
      base
    end
  end
  local-- push -->head
  head-- pull request -->base
```

## Simplifying assumptions

* We don't update PR titles and bodies.

  When a PR already exists we'll update the branch by force-pushing it but we won't update the PR's title and body even if they don't match the given `--title` and `--body` or `--body-file` arguments. It wouldn't be too hard to add updating of PR titles and bodies but it might be difficult to tell whether we're replacing an old title and body from a previous run of gh-pr-upsert or whether we're replacing a title and body that have been edited by a human, which we definitely wouldn't want to do.

* We only force-push the head branch if the final diff of the local branch is different from that of the head branch. If you've just changed the commits (for example rewording commit messages; splitting, joining and reordering commits; etc) but the final diff is the same this won't be detected and the PR won't be updated.

  It actually wouldn't be too difficult to do a commit-by-commit comparison of the difference between the base branch and the local branch and between the base branch and the head branch. Two commits would be considered "the same" if they have the same author, committer, commit message, and patch (but the date and SHA can be different), and two branches would be considered the same if they contain the same commits in the same order. I'm not sure how we would handle merge commits though. And commit-by-commit comparison isn't necessary to achieve our aim of being able to automate cookiecutter updates.

* We don't reopen PRs.

  It's possible there could be a closed (and not merged) PR that's the same as the new PR we're about to open. We don't look for these and try to reopen them, we just open new PRs.

* We don't post a comment when refusing to update PRs.

  gh-pr-upsert won't update a PR if it has someone else's commits on it. In this case it _could_ post a comment to the PR saying that it has updates but isn't sending them. Dependabot does this. It would need to check for an existing comment from itself first. We could implement this but I haven't bothered.

* We don't automatically generate PR titles and bodies from the commit messages. It's just not worth the effort of implementing this especially when you consider that commit messages should be hard-wrapped but PR bodies should not be (so we'd have to implement Markdown unwrapping).

## Testing

### Installing

To install gh-pr-upsert from this PR:

```console
$ pipx install git+https://github.com/hypothesis/gh-pr-upsert.git@initial-implementation
$ gh-pr-upsert --help
usage: gh-pr-upsert [-h] [-v] [--base-remote BASE_REMOTE] [--base-branch BASE_BRANCH] [--local-branch LOCAL_BRANCH] [--head-remote HEAD_REMOTE] [--head-branch HEAD_BRANCH] [--title TITLE] [--body BODY] [--body-file BODY_FILE]
                    [--close-comment CLOSE_COMMENT]

Create or update a GitHub pull request.

options:
  -h, --help            show this help message and exit
  -v, --version
  --base-remote BASE_REMOTE
                        the git remote to use for the base of the pull request (default: 'origin')
  --base-branch BASE_BRANCH
                        the git branch to use for the base of the pull request (default: --base-remote's default branch)
  --local-branch LOCAL_BRANCH
                        the local git branch to push (default: the current branch)
  --head-remote HEAD_REMOTE
                        the git remote to use for the head of the pull request (default: 'origin')
  --head-branch HEAD_BRANCH
                        the git branch to use for the head of the pull request (default: the branch on --head-remote with same name as --local-branch)
  --title TITLE         the title to use when creating new pull requests
  --body BODY           the body to use when creating new pull requests
  --body-file BODY_FILE
                        path to a file containing the body text to use when creating new pull requests
  --close-comment CLOSE_COMMENT
                        the comment to leave on PRs when closing them
```

To uninstall:

```console
pipx uninstall gh-pr-upsert
```

### Turn on debug logging

If the envvar `DEBUG` is set to `yes` then gh-pr-upsert will print out every command that it runs. This is useful for testing:

In bash:

```console
$ export DEBUG=yes
```

Or in fish:

```console
$ set -x DEBUG yes
```

### Create a new PR

Let's use https://github.com/hypothesis/cookiecutter-pyapp-test as a test repo. Feel free to actually do this and create test PRs in this repo:

```console
$ cd /tmp
$ git clone https://github.com/hypothesis/cookiecutter-pyapp-test.git
$ cd cookiecutter-pyapp-test
$ git switch -c my-branch
$ echo my_changes >> README.md
$ git commit README.md -m "My commit"
$ gh-pr-upsert --title "This is my title" --body "This is my body"
https://github.com/hypothesis/cookiecutter-pyapp-test/pull/60
```

You should see that it's pushed your branch and created a PR.

### It won't do anything if an up-to-date PR already exists

If you run `gh-pr-upsert` again it won't do anything if there's already an open commit with the same diff. Crucially this is even true if the local branch contains different commits (for example with a different datetime and SHA) as long as the final diff is the same:

```console
$ git reset origin/main
$ git add .
$ git commit -m "New commit"
$ gh-pr-upsert
https://github.com/hypothesis/cookiecutter-pyapp-test/pull/60
```

If you look at your PR you should see no new activity on it.

### Update an existing PR

Add another commit and call gh-pr-upsert again:

```console
$ echo more_changes >> README.md
$ git commit README.md -m "My second commit"
$ gh-pr-upsert
```

You should see that the existing PR has been updated by pushing your new commit.

You can also amend the previous commit, rebase, etc. As long as the branch's final diff has been changed the changes should be force-pushed.

### Open a PR for a branch that already exists

The branch might already exist on the remote but not have an open PR. In this case the branch will either be force-pushed or not (depending on whether its diff is different from the local branch's diff or not) and then a PR for the branch will be opened:

```console
$ git switch -c my-branch-2 main
$ echo changes >> README.md
$ git commit README.md -m "My commit"
$ # Push the branch manually so that the branch exists but has no PR.
$ git push origin my-branch-2:my-branch-2
$ # This will open a PR for the existing branch.
$ gh-pr-upsert
https://github.com/hypothesis/cookiecutter-pyapp-test/pull/66
```

### It won't force-push a branch that has other people's commits on it

```console
$ # Create and manually push a branch with someone else's commits on it.
$ git switch -c my-branch-3 main
$ git config --global user.name "Someone Else"
$ echo someone_elses_changes >> README.md
$ git commit README.md -m "Someone else's commit"
$ git push origin my-branch-3:my-branch-3
$ git config --global user.name "Sean Hammond"
$ # Change the contents of the local branch so that gh-pr-upsert's force-push would delete the other person's commit.
$ git reset --hard origin/main
$ echo my_changes >> README.md # Your changes need to be different from the other person's!
$ git commit README.md -m "My commit"
$ # gh-pr-upsert will refuse to force-push the branch because it would remove someone else's commit.
$ gh-pr-upsert
Other people have pushed commits to the branch, not updating it
```

### It'll close a PR if it's no longer needed

If there are no local changes (e.g. `make template` produced no changes) but there is an open PR then it'll close the open PR. It also leaves a customizable comment when closing the PR, and deletes the branch.

```console
$ # First create a PR.
$ git switch -c my-branch-4 main
$ echo changes >> README.md
$ git commit README.md -m "My commit"
$ gh-pr-upsert
https://github.com/hypothesis/cookiecutter-pyapp-test/pull/70
$ # Reset the branch to simulate `make template` producing no changes.
$ git reset --hard origin/main
$ # Now gh-pr-upsert will close the PR.
$ gh-pr-upsert --close-comment "I'm closing this"
Closed PR https://github.com/hypothesis/cookiecutter-pyapp-test/pull/70
Your branch has no changes compared to the default branch
```

### It won't close a PR that has someone else's commits on it

```console
$ # Create a PR with someone else's commits on it.
$ git switch -c my-branch-5 main
$ git config --global user.name "Someone Else"
$ echo someone_elses_changes >> README.md
$ git commit README.md -m "Someone else's commit"
$ gh-pr-upsert
$ git config --global user.name "Sean Hammond"
$ # Reset the branch to simulate `make template` producing no changes.
$ git reset --hard origin/main
$ # gh-pr-upsert will not close the PR because it has someone else's commits on it.
$ gh-pr-upsert
Your branch has no changes compared to the default branch
```

### Crashes

There are various ways to make it crash that I could try and make nicer but haven't bothered as it's not really necessary. When something goes wrong it prints the full error output from the `git` or `gh` command that failed and the full traceback, ugly but it's usually clear enough what went wrong.

#### "Validation Failed" when trying to create a PR for a branch that doesn't exist

This can happen if you create a PR for a branch **and then close the PR on GitHub and delete the branch** then run `gh-pr-upsert` again. The local git repo's record of the remote branch still exists: if you haven't run `git fetch --prune` then the local repo thinks the remote branch still exists. `gh-pr-upsert` will not try to force-push the remote branch since it thinks it's already the same as the local branch. But it _will_ see that no open PR exists and will try to open one. At which point it'll get this error message about trying to open a PR for a branch that doesn't exist:

```json
{"message":"Validation Failed","errors":[{"resource":"PullRequest","field":"head","code":"invalid"}],"documentation_url":"https://docs.github.com/rest/reference/pulls#create-a-pull-request"}
```

To fix it run `git fetch --prune` and then re-run `gh-pr-upsert`.

#### git push rejected: "stale info"

This can happen if the branch has been pushed or deleted on GitHub since the last time your local repo was cloned from or fetched from the remote repo. Your local repo's record of the remote branch is out of date (either having the wrong commit if the remote branch has been pushed; or thinking the remote branch still exists when it's been deleted). If additionally your local branch's diff is different from your local git repo's record of the remote branch's diff then `gh-pr-upsert` will try to force-push the remote branch. Since it uses `--force-with-lease`, attempting to force push the remote branch when the local tracking info is out of date produces an error from git:

```
To https://github.com/hypothesis/cookiecutter-pyapp-test.git
 ! [rejected]        my-branch-6 -> my-branch-6 (stale info)
```

This is actually a good thing because it prevents us from potentially deleting other people's commits that we didn't know about.

Another way to produce this error is for the branch to exist on the remote repo but your local repo's record to show that the branch _doesn't_ exist. For example creating the branch manually in GitHub's web UI can create this situation. This will produce the same stale info error. Again this is a good thing: we don't want to overwrite a branch that we didn't know about.

Another obscure edge case is when stale info makes gh-pr-upsert believe that there are other people's commits on the branch when in fact there aren't anymore (either the other people's commits or the branch itself has been deleted from GitHub). gh-pr-upsert will crash saying it won't push the branch because it contains other people's commits.

In all cases to fix it run `git fetch --prune` then re-run `gh-pr-upsert`.

#### Other crashes

Again for most of these I haven't written code to detect the situation and give a nice error message but it does print the full error output from the `git` or `gh` command that failed followed by the full traceback, so it's ugly but usually fairly obvious what went wrong. We could do so but it's probably not worth it.

* It'll crash if you're on the default branch (this one does have a nice error message and exit status)
* It'll crash if your branch has no changes compared to the base branch (this one does have a nice error message and exit status)
* It'll crash if the current working directory isn't a git repo
* It'll crash if the local git repo's `origin` remote is not the URL of a GitHub repo (including if it's a GitLab, BitBucket, etc repo)
* It'll crash if git isn't installed
* It'll crash if you haven't configured your username and email in git
* It'll crash if GitHub CLI isn't installed
* It'll crash if you aren't logged in to GitHub CLI
* If Git->GitHub CLI authentication isn't set up (so you don't have permission to push branches) I think it might prompt you interactively for a username and password if necessary
