### PR TITLE
Pin pytest to 8.3 due to compatibility issues with pytest-factoryboy

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -36,6 +36,7 @@ deps =
     lint,tests: pytest-mock
     lint,tests,functests: pytest
     lint,tests,functests: h-testkit
+    tests,functests: pytest<8.4
     tests: pytest-cov
     coverage: coverage[toml]
     lint,tests,functests: factory-boy


### PR DESCRIPTION
See:

 - https://github.com/pytest-dev/pytest-factoryboy/issues/232